### PR TITLE
Ensure that CIs with bounds outside [0, 1] are plotted in summary plots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,7 @@ Authors@R: c(
     person("Marius", "Barth", email = "marius.barth@uni-koeln.de", role = c("aut", "cre"))
     , person("Henrik", "Singmann", email = "singmann@psychologie.uzh.ch", role = c("aut"))
     , person(c("Daniel", "W."), "Heck", email = "heck@uni-mannheim.de", role = c("aut"))
+    , person("Frederik", "Aust", email = "frederik.aust@uni-koeln.de", role = c("ctb"))
   )
 URL: https://github.com/methexp/MPTmultiverse
 BugReports: https://github.com/methexp/MPTmultiverse/issues

--- a/R/summary_plots.R
+++ b/R/summary_plots.R
@@ -131,7 +131,8 @@ plot.multiverseMPT <- function(x, which = "est", save = FALSE, write.csv = FALSE
     ggplot2::facet_grid(facets = ". ~ condition") +
     ggplot2::geom_errorbar(ggplot2::aes_(ymin = ~ci_0.025, ymax = ~ci_0.975), position = dd, width = 0.4) +
     ggplot2::geom_point(position = dd) + 
-    ggplot2::ylim(0, 1) + 
+    ggplot2::coord_cartesian(ylim = c(0, 1)) +
+    # ggplot2::ylim(0, 1) + 
     ggplot2::scale_shape_manual(values = shapes)
 
   if(save) ggplot2::ggsave(paste0(prefix, "estimates.pdf"), gg_est1, h = 4.5, w = 10)


### PR DESCRIPTION
Hi, currently the ggplot method to plot the MPTmultiverse objects omits CI when their bounds are outside [0, 1]. This commit fixes this by setting `ylim` in the coordinate system rather than using `ylim()`.